### PR TITLE
Add code block template copier

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+root = true
+
+[*]
+charset = utf-8

--- a/README.md
+++ b/README.md
@@ -1,47 +1,44 @@
-# Visual Tkinter Designer
+# Markdown Project Creator
 
 <!-- Plugin description -->
-Visual Tkinter Designer is an IntelliJ IDEA plugin providing a WYSIWYG editor for creating Tkinter dialogs. Drag widgets from the floating palette onto the design surface and adjust their properties in the sidebar. Designs are stored in `.tkdesign` files and can be exported to pure Python.
+Markdown Project Creator is an IntelliJ IDEA plugin for quickly starting Markdown based projects. It also converts formatted website content from the clipboard into clean Markdown when you paste.
 <!-- Plugin description end -->
 
 ## Features
 
-- Drag-and-drop placement with resize handles
-- Compact palette showing common Tkinter widgets with icons
-- IntelliJ-style toolbar with actions for loading, saving and previewing dialogs
-- Sidebar editor for widget and dialog attributes
-- Multi-selection with alignment and grouping commands
-- Undo/redo history and keyboard shortcuts
-- Import existing Tkinter scripts
-- Preview dialogs with a chosen Python interpreter
-- Version-control diff viewer for `.tkdesign` files highlighting changed properties with color-coded cells
-- Palette customization and support for ttk widgets
-- Property panel with color pickers, font choosers, and file browsers
-- Property panel categories with search filtering and collapsible sections
-- Start from predefined templates when adding a dialog
-- Drag-and-drop hierarchy tree with rename and delete
-- Translation manager for editing localized strings
-- Settings dialog to adjust grid size, palette columns and keyboard shortcuts
+- New project wizard entry with templates for docs, blogs and API docs
+- `.editorconfig` added with UTF-8 encoding
+- Paste handler that converts HTML clipboard content to clean Markdown on paste
+- Images pasted or dropped are optimized, saved locally and referenced in Markdown
+- Custom tag mapping and exclusion rules for paste conversion
+- Keeps website formatting such as headings, bold, italics, bullet and numbered lists
+- Quick actions to insert tables, code blocks and images
+- "Copy as Template" action for YAML, JSON and TOML code blocks
+- Convert selected HTML to Markdown via **Convert HTML Selection** action
+- "Fix Markdown Formatting" action to reformat the current document
+- Auto-saves Markdown drafts across IDE sessions
+- Generate or update a Table of Contents for README files using `<!-- TOC -->` markers
+- Drag and drop images into Markdown files
+- Lint inspection with quick fix for trailing spaces
+- Snippet library with reusable blocks and front matter insertion; placeholders update across documents
+- Export Markdown to HTML or PDF
+- Setting under **Tools | Markdown Paste** to disable the auto-convert behaviour
+- Navigation tool window to browse headings, code blocks and anchors
+- Drag-and-drop heading reordering from the navigation tool window
+- Keyboard shortcuts for bold, italic and headings
+- Autocomplete for internal Markdown links and frequently used URLs
+- Broken link detection with quick fix
+- Tasks are created from checklist items on save
+- Insert citations as numbered footnotes
+- Spellcheck ignores code blocks
+- Generate release notes from recent Git commits
 
 ## Building
 
-Use the Gradle wrapper to build the plugin:
+Run the Gradle wrapper to build the plugin:
 
 ```bash
 ./gradlew buildPlugin -x signPlugin --no-daemon
 ```
 
-On Windows you can run `compilePlugin.bat` instead.
-
-The plugin archive will be created in `build/distributions`.
-
-## Usage
-
-Install the plugin and choose **Tools | Open Tkinter Designer**.  A blank design surface appears.
-
-1. Drag a widget type from the floating palette onto the canvas and drag to size it.
-2. Select the widget to edit its attributes in the right-hand sidebar.
-3. Use the toolbar to load/save `.tkdesign` files, align widgets, undo/redo, and preview.
-4. Click **Generate** when you are ready to obtain the Python code.
-
-The **Preview** action creates a temporary *Tkinter Preview* run configuration so the dialog can be executed or debugged immediately.  Global options such as grid size or palette columns are available in **Settings | Tools | Tkinter Designer**.
+The resulting plugin zip will be in `build/distributions`.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,6 +34,9 @@ dependencies {
     testImplementation(libs.junit)
     testImplementation(libs.opentest4j)
     implementation(libs.gson)
+    implementation(libs.flexmark)
+    implementation(libs.jsoup)
+    implementation(libs.openhtmltopdf)
 
     // IntelliJ Platform Gradle Plugin Dependencies Extension - read more: https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-dependencies-extension.html
     intellijPlatform {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,8 @@
 # IntelliJ Platform Artifacts Repositories -> https://plugins.jetbrains.com/docs/intellij/intellij-artifacts.html
 
-pluginGroup = org.jetbrains.plugins.template
-pluginName = Visual Tkinter Designer
-pluginRepositoryUrl = https://github.com/JetBrains/intellij-platform-plugin-template
+pluginGroup = com.mycompany.markdownproject
+pluginName = Markdown Project Creator
+pluginRepositoryUrl = https://github.com/mycompany/markdown-project
 # SemVer format -> https://semver.org
 pluginVersion = 2.1.0
 
@@ -18,7 +18,7 @@ platformVersion = 2024.3
 # Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP
 platformPlugins =
 # Example: platformBundledPlugins = com.intellij.java
-platformBundledPlugins =
+platformBundledPlugins = org.intellij.plugins.markdown
 
 # Gradle Releases -> https://github.com/gradle/gradle/releases
 gradleVersion = 8.13

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,9 @@ qodana = "2024.3.4"
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 opentest4j = { group = "org.opentest4j", name = "opentest4j", version.ref = "opentest4j" }
 gson = { group = "com.google.code.gson", name = "gson", version = "2.10.1" }
+flexmark = { group = "com.vladsch.flexmark", name = "flexmark-all", version = "0.64.8" }
+jsoup = { group = "org.jsoup", name = "jsoup", version = "1.17.2" }
+openhtmltopdf = { group = "com.openhtmltopdf", name = "openhtmltopdf-pdfbox", version = "1.0.10" }
 
 [plugins]
 changelog = { id = "org.jetbrains.changelog", version.ref = "changelog" }

--- a/src/main/kotlin/com/mycompany/markdownproject/actions/ConvertSelectionHtmlAction.kt
+++ b/src/main/kotlin/com/mycompany/markdownproject/actions/ConvertSelectionHtmlAction.kt
@@ -1,0 +1,29 @@
+package com.mycompany.markdownproject.actions
+
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.editor.EditorModificationUtil
+import com.vladsch.flexmark.formatter.Formatter
+import com.vladsch.flexmark.html2md.converter.FlexmarkHtmlConverter
+import com.vladsch.flexmark.parser.Parser
+import org.jsoup.Jsoup
+
+class ConvertSelectionHtmlAction : AnAction("Convert HTML Selection") {
+    private val converter = FlexmarkHtmlConverter.builder().build()
+    private val parser = Parser.builder().build()
+    private val formatter = Formatter.builder().build()
+
+    override fun actionPerformed(e: AnActionEvent) {
+        val editor = e.getData(com.intellij.openapi.actionSystem.CommonDataKeys.EDITOR) ?: return
+        val selection = editor.selectionModel
+        val html = selection.selectedText ?: return
+        val cleaned = Jsoup.parse(html).apply { select("style,script").remove() }.body().html()
+        val markdown = converter.convert(cleaned)
+        val formatted = formatter.render(parser.parse(markdown))
+        WriteCommandAction.runWriteCommandAction(e.project) {
+            EditorModificationUtil.insertStringAtCaret(editor, formatted, true)
+        }
+    }
+}

--- a/src/main/kotlin/com/mycompany/markdownproject/actions/CopyCodeBlockAsTemplateAction.kt
+++ b/src/main/kotlin/com/mycompany/markdownproject/actions/CopyCodeBlockAsTemplateAction.kt
@@ -1,0 +1,76 @@
+package com.mycompany.markdownproject.actions
+
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.ide.CopyPasteManager
+import com.mycompany.markdownproject.template.TemplateStrippers
+import com.mycompany.markdownproject.template.TemplateStrippers.strip
+import com.mycompany.markdownproject.template.TemplateStrippers.supports
+import com.intellij.openapi.util.TextRange
+import java.awt.datatransfer.StringSelection
+
+class CopyCodeBlockAsTemplateAction : AnAction("Copy as Template") {
+
+    override fun update(e: AnActionEvent) {
+        val editor = e.getData(CommonDataKeys.EDITOR)
+        val block = editor?.let { detectBlock(it) }
+        e.presentation.isEnabledAndVisible = block != null && supports(block.lang)
+    }
+
+    override fun actionPerformed(e: AnActionEvent) {
+        val editor = e.getRequiredData(CommonDataKeys.EDITOR)
+        val block = detectBlock(editor) ?: return
+        val template = strip(block.lang, block.content)
+        val text = "```${block.lang}\n$template\n```"
+        CopyPasteManager.getInstance().setContents(StringSelection(text))
+    }
+
+    data class Block(val lang: String, val content: String)
+
+    private fun detectBlock(editor: Editor): Block? {
+        val sel = editor.selectionModel
+        if (!sel.hasSelection()) return null
+
+        val doc = editor.document
+        val start = sel.selectionStart
+        val end = sel.selectionEnd
+
+        val startLine = doc.getLineNumber(start)
+        val endLine = doc.getLineNumber(end)
+        val openPattern = Regex("^```(\\w+)?\\s*$")
+        val closePattern = Regex("^```\\s*$")
+
+        fun lineText(line: Int): String {
+            val range = TextRange(doc.getLineStartOffset(line), doc.getLineEndOffset(line))
+            return doc.getText(range).trim()
+        }
+
+        var openLine = startLine
+        while (openLine >= 0) {
+            val text = lineText(openLine)
+            if (closePattern.matches(text)) return null
+            val m = openPattern.matchEntire(text)
+            if (m != null) break
+            openLine--
+        }
+        if (openLine < 0) return null
+        val lang = openPattern.matchEntire(lineText(openLine))!!.groupValues[1]
+        var closeLine = openLine + 1
+        while (closeLine < doc.lineCount) {
+            val t = lineText(closeLine)
+            if (openPattern.matches(t)) return null
+            if (closePattern.matches(t)) break
+            closeLine++
+        }
+        if (closeLine >= doc.lineCount) return null
+
+        val contentStart = doc.getLineStartOffset(openLine + 1)
+        val contentEnd = doc.getLineStartOffset(closeLine)
+        if (start < contentStart || end > contentEnd) return null
+
+        val content = doc.getText(TextRange(contentStart, contentEnd))
+        return Block(lang.ifEmpty { "" }, content)
+    }
+}

--- a/src/main/kotlin/com/mycompany/markdownproject/actions/ExportHtmlAction.kt
+++ b/src/main/kotlin/com/mycompany/markdownproject/actions/ExportHtmlAction.kt
@@ -1,0 +1,32 @@
+package com.mycompany.markdownproject.actions
+
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.vladsch.flexmark.html.HtmlRenderer
+import com.vladsch.flexmark.parser.Parser
+import com.intellij.openapi.fileChooser.FileChooserFactory
+import com.intellij.openapi.fileChooser.FileSaverDescriptor
+import com.openhtmltopdf.pdfboxout.PdfRendererBuilder
+import java.nio.file.Files
+import java.nio.file.Path
+
+class ExportHtmlAction : AnAction("Export Document") {
+    override fun actionPerformed(e: AnActionEvent) {
+        val editor = e.getRequiredData(com.intellij.openapi.actionSystem.CommonDataKeys.EDITOR)
+        val project = e.project ?: return
+        val parser = Parser.builder().build()
+        val renderer = HtmlRenderer.builder().build()
+        val html = renderer.render(parser.parse(editor.document.text))
+        val descriptor = FileSaverDescriptor("Export", "Choose target", "html", "pdf")
+        val dialog = FileChooserFactory.getInstance().createSaveFileDialog(descriptor, project)
+        val result = dialog.save(project.baseDir, "document") ?: return
+        val path: Path = result.file.toPath()
+        if (path.toString().endsWith(".pdf")) {
+            Files.newOutputStream(path).use { out ->
+                PdfRendererBuilder().withHtmlContent(html, null).toStream(out).run()
+            }
+        } else {
+            Files.write(path, html.toByteArray())
+        }
+    }
+}

--- a/src/main/kotlin/com/mycompany/markdownproject/actions/FixFormattingAction.kt
+++ b/src/main/kotlin/com/mycompany/markdownproject/actions/FixFormattingAction.kt
@@ -1,0 +1,24 @@
+package com.mycompany.markdownproject.actions
+
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.codeStyle.CodeStyleManager
+import org.intellij.plugins.markdown.lang.psi.impl.MarkdownFile
+
+class FixFormattingAction : AnAction("Fix Markdown Formatting") {
+    override fun actionPerformed(e: AnActionEvent) {
+        val editor = e.getData(com.intellij.openapi.actionSystem.CommonDataKeys.EDITOR) ?: return
+        val project = e.project ?: return
+        val psiFile = PsiDocumentManager.getInstance(project).getPsiFile(editor.document)
+        if (psiFile !is MarkdownFile) return
+        WriteCommandAction.runWriteCommandAction(project) {
+            CodeStyleManager.getInstance(project).reformat(psiFile)
+            PsiDocumentManager.getInstance(project).doPostponedOperationsAndUnblockDocument(editor.document)
+            FileDocumentManager.getInstance().saveDocument(editor.document)
+        }
+    }
+}

--- a/src/main/kotlin/com/mycompany/markdownproject/actions/GenerateReleaseNotesAction.kt
+++ b/src/main/kotlin/com/mycompany/markdownproject/actions/GenerateReleaseNotesAction.kt
@@ -1,0 +1,26 @@
+package com.mycompany.markdownproject.actions
+
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.vcs.VcsException
+import git4idea.history.GitHistoryUtils
+import git4idea.repo.GitRepositoryManager
+import com.intellij.testFramework.LightVirtualFile
+
+class GenerateReleaseNotesAction : AnAction("Generate Release Notes") {
+    override fun actionPerformed(e: AnActionEvent) {
+        val project = e.project ?: return
+        val repo = GitRepositoryManager.getInstance(project).repositories.firstOrNull() ?: return
+        val commits = try {
+            GitHistoryUtils.history(project, repo.root, "HEAD", "--max-count=20")
+        } catch (ex: VcsException) {
+            emptyList()
+        }
+        val builder = StringBuilder("# Release Notes\n\n")
+        commits.forEach { builder.append("- ").append(it.subject).append("\n") }
+        val file = LightVirtualFile("RELEASE_NOTES.md", builder.toString())
+        FileEditorManager.getInstance(project).openFile(file, true)
+    }
+}

--- a/src/main/kotlin/com/mycompany/markdownproject/actions/GenerateTocAction.kt
+++ b/src/main/kotlin/com/mycompany/markdownproject/actions/GenerateTocAction.kt
@@ -1,0 +1,39 @@
+package com.mycompany.markdownproject.actions
+
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.editor.Editor
+
+class GenerateTocAction : AnAction("Generate TOC") {
+    override fun actionPerformed(e: AnActionEvent) {
+        val editor = e.getData(com.intellij.openapi.actionSystem.CommonDataKeys.EDITOR) ?: return
+        val file = e.getData(com.intellij.openapi.actionSystem.CommonDataKeys.VIRTUAL_FILE) ?: return
+        if (!file.name.equals("README.md", ignoreCase = true)) return
+        val text = editor.document.text
+        val tocContent = buildString {
+            text.lineSequence().forEach { line ->
+                val match = Regex("^(#{1,6})\\s+(.*)").find(line)
+                if (match != null) {
+                    val level = match.groupValues[1].length
+                    val heading = match.groupValues[2]
+                    append("  ".repeat(level - 1))
+                    append("- [${heading}](#${heading.lowercase().replace(' ', '-')})\n")
+                }
+            }
+        }
+        val doc = editor.document
+        val startMarker = "<!-- TOC -->"
+        val endMarker = "<!-- TOC END -->"
+        WriteCommandAction.runWriteCommandAction(editor.project) {
+            val existingStart = text.indexOf(startMarker)
+            val existingEnd = text.indexOf(endMarker)
+            val tocBlock = "$startMarker\n$tocContent$endMarker\n"
+            if (existingStart != -1 && existingEnd != -1 && existingEnd > existingStart) {
+                doc.replaceString(existingStart, existingEnd + endMarker.length, tocBlock)
+            } else {
+                doc.insertString(0, tocBlock + "\n")
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/mycompany/markdownproject/actions/InsertCitationAction.kt
+++ b/src/main/kotlin/com/mycompany/markdownproject/actions/InsertCitationAction.kt
@@ -1,0 +1,29 @@
+package com.mycompany.markdownproject.actions
+
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.ui.Messages
+import com.intellij.psi.PsiDocumentManager
+import org.intellij.plugins.markdown.lang.psi.impl.MarkdownFile
+
+class InsertCitationAction : AnAction("Insert Citation") {
+    override fun actionPerformed(e: AnActionEvent) {
+        val project = e.project ?: return
+        val editor = e.getData(com.intellij.openapi.actionSystem.CommonDataKeys.EDITOR) ?: return
+        val psiFile = PsiDocumentManager.getInstance(project).getPsiFile(editor.document) as? MarkdownFile ?: return
+        val doc = editor.document
+        val citation = Messages.showInputDialog(project, "Citation text", "Insert Citation", null) ?: return
+        val footnoteRegex = Regex("\\n\\[\\^(\\d+)]:")
+        val existingNumbers = footnoteRegex.findAll(doc.text).map { it.groupValues[1].toInt() }.toList()
+        val next = (existingNumbers.maxOrNull() ?: 0) + 1
+        val insertText = "[^$next]"
+        WriteCommandAction.runWriteCommandAction(project) {
+            editor.document.insertString(editor.caretModel.offset, insertText)
+            val footnote = "\n[^$next]: $citation"
+            doc.insertString(doc.textLength, footnote)
+            PsiDocumentManager.getInstance(project).commitDocument(doc)
+        }
+    }
+}

--- a/src/main/kotlin/com/mycompany/markdownproject/actions/InsertCodeBlockAction.kt
+++ b/src/main/kotlin/com/mycompany/markdownproject/actions/InsertCodeBlockAction.kt
@@ -1,0 +1,21 @@
+package com.mycompany.markdownproject.actions
+
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.editor.Editor
+
+class InsertCodeBlockAction : AnAction("Insert Code Block") {
+    override fun actionPerformed(e: AnActionEvent) {
+        val editor = e.getData(com.intellij.openapi.actionSystem.CommonDataKeys.EDITOR) ?: return
+        insertText(editor, "```\n\n```\n")
+    }
+
+    private fun insertText(editor: Editor, text: String) {
+        WriteCommandAction.runWriteCommandAction(editor.project) {
+            val caret = editor.caretModel.offset
+            editor.document.insertString(caret, text)
+            editor.caretModel.moveToOffset(caret + 4)
+        }
+    }
+}

--- a/src/main/kotlin/com/mycompany/markdownproject/actions/InsertFrontMatterAction.kt
+++ b/src/main/kotlin/com/mycompany/markdownproject/actions/InsertFrontMatterAction.kt
@@ -1,0 +1,14 @@
+package com.mycompany.markdownproject.actions
+
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.command.WriteCommandAction
+
+class InsertFrontMatterAction : AnAction("Insert Front Matter") {
+    override fun actionPerformed(e: AnActionEvent) {
+        val editor = e.getRequiredData(com.intellij.openapi.actionSystem.CommonDataKeys.EDITOR)
+        WriteCommandAction.runWriteCommandAction(editor.project) {
+            editor.document.insertString(0, "---\ntitle: \n---\n\n")
+        }
+    }
+}

--- a/src/main/kotlin/com/mycompany/markdownproject/actions/InsertImageAction.kt
+++ b/src/main/kotlin/com/mycompany/markdownproject/actions/InsertImageAction.kt
@@ -1,0 +1,19 @@
+package com.mycompany.markdownproject.actions
+
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.editor.Editor
+
+class InsertImageAction : AnAction("Insert Image") {
+    override fun actionPerformed(e: AnActionEvent) {
+        val editor = e.getData(com.intellij.openapi.actionSystem.CommonDataKeys.EDITOR) ?: return
+        insertText(editor, "![alt text](image.png)\n")
+    }
+
+    private fun insertText(editor: Editor, text: String) {
+        WriteCommandAction.runWriteCommandAction(editor.project) {
+            editor.document.insertString(editor.caretModel.offset, text)
+        }
+    }
+}

--- a/src/main/kotlin/com/mycompany/markdownproject/actions/InsertSnippetAction.kt
+++ b/src/main/kotlin/com/mycompany/markdownproject/actions/InsertSnippetAction.kt
@@ -1,0 +1,26 @@
+package com.mycompany.markdownproject.actions
+
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.ui.popup.JBPopupFactory
+import com.intellij.ui.components.JBList
+import com.mycompany.markdownproject.snippets.SnippetService
+
+class InsertSnippetAction : AnAction("Insert Snippet") {
+    override fun actionPerformed(e: AnActionEvent) {
+        val editor = e.getRequiredData(com.intellij.openapi.actionSystem.CommonDataKeys.EDITOR)
+        val snippets = SnippetService.instance().state.snippets
+        if (snippets.isEmpty()) return
+        val list = JBList(snippets.map { it.name })
+        JBPopupFactory.getInstance().createListPopupBuilder(list).setTitle("Choose snippet").setItemChoosenCallback {
+            val idx = list.selectedIndex
+            if (idx >= 0) {
+                val text = snippets[idx].text
+                WriteCommandAction.runWriteCommandAction(editor.project) {
+                    editor.document.insertString(editor.caretModel.offset, text)
+                }
+            }
+        }.createPopup().showInBestPositionFor(e.dataContext)
+    }
+}

--- a/src/main/kotlin/com/mycompany/markdownproject/actions/InsertTableAction.kt
+++ b/src/main/kotlin/com/mycompany/markdownproject/actions/InsertTableAction.kt
@@ -1,0 +1,22 @@
+package com.mycompany.markdownproject.actions
+
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.EditorFactory
+
+class InsertTableAction : AnAction("Insert Markdown Table") {
+    override fun actionPerformed(e: AnActionEvent) {
+        val editor = e.getData(com.intellij.openapi.actionSystem.CommonDataKeys.EDITOR) ?: return
+        insertText(editor, "| Header 1 | Header 2 |\n|---------|---------|\n|         |         |\n")
+    }
+
+    private fun insertText(editor: Editor, text: String) {
+        val project = editor.project
+        WriteCommandAction.runWriteCommandAction(project) {
+            val caretModel = editor.caretModel
+            editor.document.insertString(caretModel.offset, text)
+        }
+    }
+}

--- a/src/main/kotlin/com/mycompany/markdownproject/completion/LinkCompletionContributor.kt
+++ b/src/main/kotlin/com/mycompany/markdownproject/completion/LinkCompletionContributor.kt
@@ -1,0 +1,37 @@
+package com.mycompany.markdownproject.completion
+
+import com.intellij.codeInsight.completion.CompletionContributor
+import com.intellij.codeInsight.completion.CompletionParameters
+import com.intellij.codeInsight.completion.CompletionResultSet
+import com.intellij.codeInsight.completion.CompletionType
+import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VfsUtil
+import com.mycompany.markdownproject.history.LinkHistoryService
+import org.intellij.plugins.markdown.lang.MarkdownFileType
+
+class LinkCompletionContributor : CompletionContributor() {
+    override fun fillCompletionVariants(parameters: CompletionParameters, result: CompletionResultSet) {
+        val project = parameters.editor.project ?: return
+        if (parameters.completionType != CompletionType.BASIC) return
+        val prefix = result.prefixMatcher.prefix
+        suggestFiles(project, prefix).forEach { path ->
+            result.addElement(LookupElementBuilder.create(path))
+        }
+        LinkHistoryService.getInstance(project).topMatches(prefix).forEach { url ->
+            result.addElement(LookupElementBuilder.create(url).withTypeText("recent"))
+        }
+    }
+
+    private fun suggestFiles(project: Project, prefix: String): List<String> {
+        val result = mutableListOf<String>()
+        VfsUtil.iterateChildrenRecursively(project.baseDir, { true }) { file ->
+            if (!file.isDirectory && file.fileType == MarkdownFileType.INSTANCE) {
+                val rel = VfsUtil.findRelativePath(project.baseDir, file, '/')
+                if (rel != null && rel.startsWith(prefix)) result.add(rel)
+            }
+            true
+        }
+        return result
+    }
+}

--- a/src/main/kotlin/com/mycompany/markdownproject/draft/DraftListener.kt
+++ b/src/main/kotlin/com/mycompany/markdownproject/draft/DraftListener.kt
@@ -1,0 +1,15 @@
+package com.mycompany.markdownproject.draft
+
+import com.intellij.openapi.editor.event.EditorFactoryEvent
+import com.intellij.openapi.editor.event.EditorFactoryListener
+import com.intellij.openapi.fileEditor.FileDocumentManager
+
+class DraftListener : EditorFactoryListener {
+    override fun editorReleased(event: EditorFactoryEvent) {
+        val editor = event.editor
+        val file = FileDocumentManager.getInstance().getFile(editor.document) ?: return
+        if (file.fileType.defaultExtension == "md") {
+            DraftService.instance().saveDraft(file.path, editor.document.text)
+        }
+    }
+}

--- a/src/main/kotlin/com/mycompany/markdownproject/draft/DraftRestorer.kt
+++ b/src/main/kotlin/com/mycompany/markdownproject/draft/DraftRestorer.kt
@@ -1,0 +1,16 @@
+package com.mycompany.markdownproject.draft
+
+import com.intellij.openapi.editor.event.EditorFactoryEvent
+import com.intellij.openapi.editor.event.EditorFactoryListener
+import com.intellij.openapi.fileEditor.FileDocumentManager
+
+class DraftRestorer : EditorFactoryListener {
+    override fun editorCreated(event: EditorFactoryEvent) {
+        val editor = event.editor
+        val file = FileDocumentManager.getInstance().getFile(editor.document) ?: return
+        if (file.fileType.defaultExtension == "md") {
+            val draft = DraftService.instance().getDraft(file.path) ?: return
+            editor.document.setText(draft)
+        }
+    }
+}

--- a/src/main/kotlin/com/mycompany/markdownproject/draft/DraftService.kt
+++ b/src/main/kotlin/com/mycompany/markdownproject/draft/DraftService.kt
@@ -1,0 +1,24 @@
+package com.mycompany.markdownproject.draft
+
+import com.intellij.openapi.components.PersistentStateComponent
+import com.intellij.openapi.components.State
+import com.intellij.openapi.components.Storage
+import com.intellij.openapi.components.service
+
+@State(name = "MarkdownDraftService", storages = [Storage("markdownDrafts.xml")])
+class DraftService : PersistentStateComponent<DraftService.State> {
+    data class State(var drafts: MutableMap<String, String> = mutableMapOf())
+    private var myState = State()
+    override fun getState(): State = myState
+    override fun loadState(state: State) { myState = state }
+
+    fun saveDraft(path: String, text: String) {
+        myState.drafts[path] = text
+    }
+
+    fun getDraft(path: String): String? = myState.drafts[path]
+
+    companion object {
+        fun instance(): DraftService = service()
+    }
+}

--- a/src/main/kotlin/com/mycompany/markdownproject/history/LinkHistoryService.kt
+++ b/src/main/kotlin/com/mycompany/markdownproject/history/LinkHistoryService.kt
@@ -1,0 +1,34 @@
+package com.mycompany.markdownproject.history
+
+import com.intellij.openapi.components.PersistentStateComponent
+import com.intellij.openapi.components.State
+import com.intellij.openapi.components.Storage
+import com.intellij.openapi.components.service
+import com.intellij.openapi.project.Project
+
+@State(name = "LinkHistoryService", storages = [Storage("markdownLinkHistory.xml")])
+class LinkHistoryService : PersistentStateComponent<LinkHistoryService.State> {
+    data class State(var urls: MutableMap<String, Int> = mutableMapOf())
+    private var myState = State()
+
+    override fun getState(): State = myState
+    override fun loadState(state: State) { myState = state }
+
+    fun record(url: String) {
+        val count = myState.urls[url] ?: 0
+        myState.urls[url] = count + 1
+    }
+
+    fun topMatches(prefix: String, limit: Int = 5): List<String> {
+        return myState.urls
+            .filterKeys { it.startsWith(prefix) }
+            .toList()
+            .sortedByDescending { it.second }
+            .map { it.first }
+            .take(limit)
+    }
+
+    companion object {
+        fun getInstance(project: Project): LinkHistoryService = project.service()
+    }
+}

--- a/src/main/kotlin/com/mycompany/markdownproject/inspections/BrokenLinkInspection.kt
+++ b/src/main/kotlin/com/mycompany/markdownproject/inspections/BrokenLinkInspection.kt
@@ -1,0 +1,68 @@
+package com.mycompany.markdownproject.inspections
+
+import com.intellij.codeInspection.LocalInspectionTool
+import com.intellij.codeInspection.LocalQuickFix
+import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.codeInspection.ProblemHighlightType
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElementVisitor
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiRecursiveElementWalkingVisitor
+import com.intellij.util.ui.UIUtil
+import org.intellij.plugins.markdown.lang.MarkdownLanguage
+import org.intellij.plugins.markdown.lang.psi.MarkdownElementTypes
+import org.intellij.plugins.markdown.lang.psi.MarkdownPsiElement
+import org.intellij.plugins.markdown.lang.psi.impl.MarkdownFile
+import org.intellij.plugins.markdown.lang.psi.impl.MarkdownLinkDestinationImpl
+import java.net.HttpURLConnection
+import java.net.URL
+
+class BrokenLinkInspection : LocalInspectionTool() {
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor {
+        return object : PsiRecursiveElementWalkingVisitor() {
+            override fun visitFile(file: PsiFile) {
+                if (file !is MarkdownFile) return
+                super.visitFile(file)
+            }
+
+            override fun visitElement(element: com.intellij.psi.PsiElement) {
+                if (element is MarkdownLinkDestinationImpl) {
+                    val url = element.text
+                    if (!url.startsWith("http")) {
+                        val vf = element.containingFile.virtualFile.parent?.findFileByRelativePath(url)
+                        if (vf == null) {
+                            holder.registerProblem(element, "Broken link", ProblemHighlightType.GENERIC_ERROR_OR_WARNING, RemoveLinkFix())
+                        }
+                    } else {
+                        try {
+                            val conn = URL(url).openConnection() as HttpURLConnection
+                            conn.requestMethod = "HEAD"
+                            conn.connectTimeout = 2000
+                            val code = conn.responseCode
+                            if (code >= 400) {
+                                holder.registerProblem(element, "Unreachable link", ProblemHighlightType.GENERIC_ERROR_OR_WARNING, RemoveLinkFix())
+                            }
+                        } catch (e: Exception) {
+                            holder.registerProblem(element, "Unreachable link", ProblemHighlightType.GENERIC_ERROR_OR_WARNING, RemoveLinkFix())
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private class RemoveLinkFix : LocalQuickFix {
+        override fun getName() = "Remove link"
+        override fun getFamilyName() = name
+        override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+            val element = descriptor.psiElement as? MarkdownPsiElement ?: return
+            val doc = element.containingFile.viewProvider.document ?: return
+            val range = element.textRange
+            com.intellij.openapi.command.WriteCommandAction.runWriteCommandAction(project) {
+                doc.deleteString(range.startOffset, range.endOffset)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/mycompany/markdownproject/inspections/MarkdownLintInspection.kt
+++ b/src/main/kotlin/com/mycompany/markdownproject/inspections/MarkdownLintInspection.kt
@@ -1,0 +1,32 @@
+package com.mycompany.markdownproject.inspections
+
+import com.intellij.codeInspection.LocalInspectionTool
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiElementVisitor
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiRecursiveElementWalkingVisitor
+
+import com.mycompany.markdownproject.inspections.RemoveTrailingSpaceFix
+import org.intellij.plugins.markdown.lang.psi.impl.MarkdownFile
+
+class MarkdownLintInspection : LocalInspectionTool() {
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor {
+        return object : PsiElementVisitor() {
+            override fun visitFile(file: PsiFile) {
+                if (file is MarkdownFile) {
+                    val doc = file.viewProvider.document ?: return
+                    var offset = 0
+                    doc.text.split('\n').forEach { line ->
+                        if (line.endsWith(" ")) {
+                            val range = TextRange(offset + line.length - 1, offset + line.length)
+                            holder.registerProblem(file, range, "Trailing whitespace", RemoveTrailingSpaceFix())
+                        }
+                        offset += line.length + 1
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/mycompany/markdownproject/inspections/RemoveTrailingSpaceFix.kt
+++ b/src/main/kotlin/com/mycompany/markdownproject/inspections/RemoveTrailingSpaceFix.kt
@@ -1,0 +1,20 @@
+package com.mycompany.markdownproject.inspections
+
+import com.intellij.codeInspection.LocalQuickFix
+import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiFile
+
+class RemoveTrailingSpaceFix : LocalQuickFix {
+    override fun getFamilyName(): String = "Remove trailing spaces"
+
+    override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+        val file = descriptor.psiElement.containingFile ?: return
+        val document = file.viewProvider.document ?: return
+        WriteCommandAction.runWriteCommandAction(project) {
+            val cleaned = document.text.lines().joinToString("\n") { it.trimEnd() }
+            document.setText(cleaned)
+        }
+    }
+}

--- a/src/main/kotlin/com/mycompany/markdownproject/paste/ImageDropHandler.kt
+++ b/src/main/kotlin/com/mycompany/markdownproject/paste/ImageDropHandler.kt
@@ -1,0 +1,51 @@
+package com.mycompany.markdownproject.paste
+
+import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.ex.EditorEx
+import java.awt.datatransfer.DataFlavor
+import javax.swing.TransferHandler
+import javax.imageio.ImageIO
+import java.awt.image.BufferedImage
+import java.io.ByteArrayOutputStream
+
+class ImageDropHandler : TransferHandler() {
+    override fun importData(support: TransferHandler.TransferSupport): Boolean {
+        val editor = support.component as? EditorEx ?: return false
+        val file = FileDocumentManager.getInstance().getFile(editor.document) ?: return false
+        if (file.fileType.defaultExtension != "md") return false
+        val t = support.transferable
+        if (t.isDataFlavorSupported(DataFlavor.javaFileListFlavor)) {
+            val files = t.getTransferData(DataFlavor.javaFileListFlavor) as java.util.List<*>
+            val f = files.firstOrNull() as? java.io.File ?: return false
+            val name = f.name
+            val dir = file.parent
+            val target = dir.findOrCreateChildData(this, name)
+            target.setBinaryContent(f.readBytes())
+            insertLink(editor, name)
+            return true
+        }
+        if (t.isDataFlavorSupported(DataFlavor.imageFlavor)) {
+            val image = t.getTransferData(DataFlavor.imageFlavor) as? BufferedImage ?: return false
+            val name = "dropped_${System.currentTimeMillis()}.png"
+            val target = file.parent.findOrCreateChildData(this, name)
+            ByteArrayOutputStream().use { out ->
+                ImageIO.write(image, "png", out)
+                target.setBinaryContent(out.toByteArray())
+            }
+            insertLink(editor, name)
+            return true
+        }
+        return false
+    }
+
+    private fun insertLink(editor: Editor, name: String) {
+        com.intellij.openapi.command.WriteCommandAction.runWriteCommandAction(editor.project) {
+            editor.document.insertString(editor.caretModel.offset, "![image](${name})")
+        }
+    }
+
+    override fun canImport(support: TransferHandler.TransferSupport): Boolean {
+        return support.isDataFlavorSupported(DataFlavor.javaFileListFlavor) || support.isDataFlavorSupported(DataFlavor.imageFlavor)
+    }
+}

--- a/src/main/kotlin/com/mycompany/markdownproject/paste/MarkdownPasteHandler.kt
+++ b/src/main/kotlin/com/mycompany/markdownproject/paste/MarkdownPasteHandler.kt
@@ -1,0 +1,137 @@
+package com.mycompany.markdownproject.paste
+
+import com.intellij.openapi.actionSystem.IdeActions
+import com.intellij.openapi.actionSystem.DataContext
+import com.intellij.openapi.editor.Caret
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.actionSystem.EditorActionHandler
+import com.intellij.openapi.editor.actionSystem.EditorActionManager
+import com.intellij.openapi.ide.CopyPasteManager
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.psi.PsiDocumentManager
+import com.vladsch.flexmark.formatter.Formatter
+import com.vladsch.flexmark.html2md.converter.FlexmarkHtmlConverter
+import com.vladsch.flexmark.parser.Parser
+import org.jsoup.Jsoup
+import java.awt.Image
+import java.awt.image.BufferedImage
+import java.awt.datatransfer.DataFlavor
+import java.awt.datatransfer.Transferable
+import javax.imageio.ImageIO
+import java.awt.Graphics2D
+import java.io.ByteArrayOutputStream
+
+class MarkdownPasteHandler : EditorActionHandler() {
+    private val original = EditorActionManager.getInstance().getActionHandler(IdeActions.ACTION_PASTE)
+    private val htmlConverter = FlexmarkHtmlConverter.builder().build()
+    private val parser = Parser.builder().build()
+    private val formatter = Formatter.builder().build()
+
+    private fun extractHtml(transferable: Transferable?): String? {
+        if (transferable == null) return null
+        listOf(DataFlavor.fragmentHtmlFlavor, DataFlavor.allHtmlFlavor).forEach { flavor ->
+            if (transferable.isDataFlavorSupported(flavor)) {
+                return transferable.getTransferData(flavor) as? String
+            }
+        }
+        if (transferable.isDataFlavorSupported(DataFlavor.stringFlavor)) {
+            val text = transferable.getTransferData(DataFlavor.stringFlavor) as? String
+            if (text != null && text.contains('<') && text.contains('>')) {
+                return text
+            }
+        }
+        return null
+    }
+
+    private fun extractImage(transferable: Transferable?): Image? {
+        if (transferable == null) return null
+        if (transferable.isDataFlavorSupported(DataFlavor.imageFlavor)) {
+            return transferable.getTransferData(DataFlavor.imageFlavor) as? Image
+        }
+        return null
+    }
+
+    private fun optimize(image: BufferedImage, maxWidth: Int): BufferedImage {
+        if (image.width <= maxWidth) return image
+        val ratio = maxWidth.toDouble() / image.width
+        val height = (image.height * ratio).toInt()
+        val scaled = BufferedImage(maxWidth, height, BufferedImage.TYPE_INT_ARGB)
+        val g: Graphics2D = scaled.createGraphics()
+        g.drawImage(image, 0, 0, maxWidth, height, null)
+        g.dispose()
+        return scaled
+    }
+
+    private fun sanitizeHtml(html: String, settings: com.mycompany.markdownproject.settings.MarkdownPasteSettings.State): String {
+        val doc = Jsoup.parse(html)
+        doc.select("style,script").remove()
+        settings.excludedTags.forEach { tag ->
+            doc.select(tag).remove()
+        }
+        settings.tagMappings.forEach { (from, to) ->
+            doc.select(from).forEach { e -> e.tagName(to) }
+        }
+        doc.select("[style*=font-weight:bold]").forEach { element ->
+            element.tagName(settings.tagMappings.getOrDefault("b", "b"))
+            element.removeAttr("style")
+        }
+        doc.select("[style*=font-style:italic]").forEach { element ->
+            element.tagName(settings.tagMappings.getOrDefault("i", "i"))
+            element.removeAttr("style")
+        }
+        return doc.body().html()
+    }
+
+
+    override fun doExecute(editor: Editor, caret: Caret?, dataContext: DataContext) {
+        val project = editor.project
+        val psiFile = project?.let { PsiDocumentManager.getInstance(it).getPsiFile(editor.document) }
+        if (psiFile == null || psiFile.fileType.defaultExtension != "md") {
+            original.execute(editor, caret, dataContext)
+            return
+        }
+        val settings = com.mycompany.markdownproject.settings.MarkdownPasteSettings.instance()
+        val state = settings.state
+        if (!state.autoConvert) {
+            original.execute(editor, caret, dataContext)
+            return
+        }
+        val clipboard = CopyPasteManager.getInstance().contents
+        val html = extractHtml(clipboard)
+        val image = extractImage(clipboard)
+        if (image != null) {
+            val psiFile = PsiDocumentManager.getInstance(project!!).getPsiFile(editor.document) ?: return
+            val vFile = psiFile.virtualFile
+            val dir = vFile.parent
+            val name = "pasted_${System.currentTimeMillis()}.png"
+            val target = dir.findOrCreateChildData(this, name)
+            val buffered = image as? java.awt.image.BufferedImage ?: return
+            val optimized = optimize(buffered, state.maxImageWidth)
+            ByteArrayOutputStream().use { out ->
+                ImageIO.write(optimized, "png", out)
+                target.setBinaryContent(out.toByteArray())
+            }
+            val markdown = "![image](${name})"
+            WriteCommandAction.runWriteCommandAction(project) {
+                val model = editor.selectionModel
+                val start = model.selectionStart
+                val end = model.selectionEnd
+                editor.document.replaceString(start, end, markdown)
+                PsiDocumentManager.getInstance(project).commitDocument(editor.document)
+            }
+        } else if (html != null) {
+            val cleaned = sanitizeHtml(html, state)
+            val markdown = htmlConverter.convert(cleaned)
+            val formatted = formatter.render(parser.parse(markdown))
+            WriteCommandAction.runWriteCommandAction(project) {
+                val model = editor.selectionModel
+                val start = model.selectionStart
+                val end = model.selectionEnd
+                editor.document.replaceString(start, end, formatted)
+                PsiDocumentManager.getInstance(project!!).commitDocument(editor.document)
+            }
+        } else {
+            original.execute(editor, caret, dataContext)
+        }
+    }
+}

--- a/src/main/kotlin/com/mycompany/markdownproject/settings/MarkdownPasteConfigurable.kt
+++ b/src/main/kotlin/com/mycompany/markdownproject/settings/MarkdownPasteConfigurable.kt
@@ -1,0 +1,59 @@
+package com.mycompany.markdownproject.settings
+
+import com.intellij.openapi.options.SearchableConfigurable
+import javax.swing.*
+
+class MarkdownPasteConfigurable : SearchableConfigurable {
+    private val autoBox = JCheckBox("Auto-convert HTML clipboard content to Markdown", true)
+    private val mappingField = JTextField(30)
+    private val excludedField = JTextField(20)
+    private val widthField = JSpinner(SpinnerNumberModel(800, 100, 5000, 50))
+
+    override fun getId(): String = "markdown.paste.settings"
+    override fun getDisplayName(): String = "Markdown Paste"
+
+    override fun createComponent(): JComponent {
+        val panel = JPanel()
+        panel.layout = BoxLayout(panel, BoxLayout.Y_AXIS)
+        panel.add(autoBox)
+        panel.add(JLabel("Tag mappings (tag=replacement, ...):"))
+        panel.add(mappingField)
+        panel.add(JLabel("Excluded tags (comma-separated):"))
+        panel.add(excludedField)
+        panel.add(JLabel("Max pasted image width:"))
+        panel.add(widthField)
+        reset()
+        return panel
+    }
+
+    override fun isModified(): Boolean {
+        val settings = MarkdownPasteSettings.instance().state
+        return autoBox.isSelected != settings.autoConvert ||
+            mappingField.text != settings.tagMappings.entries.joinToString { "${it.key}=${it.value}" } ||
+            excludedField.text != settings.excludedTags.joinToString(",") ||
+            (widthField.value as Int) != settings.maxImageWidth
+    }
+
+    override fun apply() {
+        val state = MarkdownPasteSettings.instance().state
+        state.autoConvert = autoBox.isSelected
+        state.tagMappings = mappingField.text.split(',')
+            .mapNotNull { it.split('=')
+                .takeIf { parts -> parts.size == 2 }
+                ?.let { parts -> parts[0].trim() to parts[1].trim() } }
+            .toMap().toMutableMap()
+        state.excludedTags = excludedField.text.split(',')
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+            .toMutableSet()
+        state.maxImageWidth = widthField.value as Int
+    }
+
+    override fun reset() {
+        val state = MarkdownPasteSettings.instance().state
+        autoBox.isSelected = state.autoConvert
+        mappingField.text = state.tagMappings.entries.joinToString { "${it.key}=${it.value}" }
+        excludedField.text = state.excludedTags.joinToString(",")
+        widthField.value = state.maxImageWidth
+    }
+}

--- a/src/main/kotlin/com/mycompany/markdownproject/settings/MarkdownPasteSettings.kt
+++ b/src/main/kotlin/com/mycompany/markdownproject/settings/MarkdownPasteSettings.kt
@@ -1,0 +1,26 @@
+package com.mycompany.markdownproject.settings
+
+import com.intellij.openapi.components.PersistentStateComponent
+import com.intellij.openapi.components.State
+import com.intellij.openapi.components.Storage
+import com.intellij.openapi.components.service
+
+@State(name = "MarkdownPasteSettings", storages = [Storage("markdownPaste.xml")])
+class MarkdownPasteSettings : PersistentStateComponent<MarkdownPasteSettings.State> {
+    data class State(
+        var autoConvert: Boolean = true,
+        var tagMappings: MutableMap<String, String> = mutableMapOf(
+            "b" to "b",
+            "i" to "i"
+        ),
+        var excludedTags: MutableSet<String> = mutableSetOf(),
+        var maxImageWidth: Int = 800
+    )
+    private var myState = State()
+    override fun getState(): State = myState
+    override fun loadState(state: State) { myState = state }
+
+    companion object {
+        fun instance(): MarkdownPasteSettings = service()
+    }
+}

--- a/src/main/kotlin/com/mycompany/markdownproject/snippets/SnippetService.kt
+++ b/src/main/kotlin/com/mycompany/markdownproject/snippets/SnippetService.kt
@@ -1,0 +1,19 @@
+package com.mycompany.markdownproject.snippets
+
+import com.intellij.openapi.components.PersistentStateComponent
+import com.intellij.openapi.components.State
+import com.intellij.openapi.components.Storage
+import com.intellij.openapi.components.service
+
+@State(name = "SnippetService", storages = [Storage("markdownSnippets.xml")])
+class SnippetService : PersistentStateComponent<SnippetService.State> {
+    data class Snippet(val name: String, val text: String)
+    data class State(var snippets: MutableList<Snippet> = mutableListOf())
+    private var myState = State(mutableListOf(Snippet("note", "> **Note:** ")))
+    override fun getState(): State = myState
+    override fun loadState(state: State) { myState = state }
+
+    companion object {
+        fun instance(): SnippetService = service()
+    }
+}

--- a/src/main/kotlin/com/mycompany/markdownproject/spellcheck/MarkdownSpellcheckStrategy.kt
+++ b/src/main/kotlin/com/mycompany/markdownproject/spellcheck/MarkdownSpellcheckStrategy.kt
@@ -1,0 +1,13 @@
+package com.mycompany.markdownproject.spellcheck
+
+import com.intellij.spellchecker.tokenizer.Tokenizer
+import com.intellij.spellchecker.tokenizer.SpellcheckingStrategy
+import com.intellij.psi.PsiElement
+import org.intellij.plugins.markdown.lang.psi.impl.MarkdownCodeFence
+
+class MarkdownSpellcheckStrategy : SpellcheckingStrategy() {
+    override fun getTokenizer(element: PsiElement): Tokenizer<*> {
+        if (element is MarkdownCodeFence) return EMPTY_TOKENIZER
+        return super.getTokenizer(element)
+    }
+}

--- a/src/main/kotlin/com/mycompany/markdownproject/tasks/TaskService.kt
+++ b/src/main/kotlin/com/mycompany/markdownproject/tasks/TaskService.kt
@@ -1,0 +1,22 @@
+package com.mycompany.markdownproject.tasks
+
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
+import com.intellij.tasks.TaskManager
+import com.intellij.openapi.project.Project
+
+@Service
+class TaskService(private val project: Project) {
+    fun updateTasksFromFile(path: String, text: String) {
+        val manager = TaskManager.getManager(project) ?: return
+        val regex = Regex("""^- \[( |x)] (.+)""", RegexOption.MULTILINE)
+        regex.findAll(text).forEach { m ->
+            val summary = m.groupValues[2]
+            manager.createLocalTask(summary)
+        }
+    }
+
+    companion object {
+        fun getInstance(project: Project): TaskService = project.service()
+    }
+}

--- a/src/main/kotlin/com/mycompany/markdownproject/tasks/TaskUpdater.kt
+++ b/src/main/kotlin/com/mycompany/markdownproject/tasks/TaskUpdater.kt
@@ -1,0 +1,38 @@
+package com.mycompany.markdownproject.tasks
+
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.openapi.fileEditor.FileDocumentManagerListener
+import com.intellij.openapi.project.ProjectLocator
+import com.mycompany.markdownproject.snippets.SnippetService
+import com.mycompany.markdownproject.history.LinkHistoryService
+
+class TaskUpdater : FileDocumentManagerListener {
+    override fun beforeDocumentSaving(document: Document) {
+        val file = FileDocumentManager.getInstance().getFile(document) ?: return
+        if (file.fileType.defaultExtension != "md") return
+        val project = ProjectLocator.getInstance().guessProjectForFile(file) ?: return
+        val text = document.text
+        TaskService.getInstance(project).updateTasksFromFile(file.path, text)
+
+        // update link history
+        val urlRegex = Regex("\\((https?://[^)\\s]+)\\)")
+        urlRegex.findAll(text).forEach { m ->
+            LinkHistoryService.getInstance(project).record(m.groupValues[1])
+        }
+
+        // expand snippet placeholders {{snippet:name}}
+        var expanded = text
+        val snippetRegex = Regex("\\{\\{snippet:([a-zA-Z0-9_-]+)}}")
+        snippetRegex.findAll(text).forEach { m ->
+            val name = m.groupValues[1]
+            val snippet = SnippetService.instance().state.snippets.find { it.name == name }?.text
+            if (snippet != null) {
+                expanded = expanded.replace(m.value, snippet)
+            }
+        }
+        if (expanded != text) {
+            document.setText(expanded)
+        }
+    }
+}

--- a/src/main/kotlin/com/mycompany/markdownproject/template/JsonTemplateStripper.kt
+++ b/src/main/kotlin/com/mycompany/markdownproject/template/JsonTemplateStripper.kt
@@ -1,0 +1,41 @@
+package com.mycompany.markdownproject.template
+
+import com.google.gson.*
+
+class JsonTemplateStripper : TemplateStripper {
+    private val gson = Gson()
+    private val pretty = GsonBuilder().setPrettyPrinting().create()
+
+    override fun strip(content: String): String {
+        return try {
+            val element = gson.fromJson(content, JsonElement::class.java)
+            val stripped = stripElement(element)
+            pretty.toJson(stripped).trim()
+        } catch (e: Exception) {
+            content
+        }
+    }
+
+    private fun stripElement(el: JsonElement): JsonElement {
+        return when {
+            el.isJsonObject -> {
+                val obj = JsonObject()
+                for ((k, v) in el.asJsonObject.entrySet()) {
+                    obj.add(k, stripElement(v))
+                }
+                obj
+            }
+            el.isJsonArray -> JsonArray()
+            el.isJsonPrimitive -> {
+                val p = el.asJsonPrimitive
+                when {
+                    p.isString -> JsonPrimitive("")
+                    p.isNumber -> JsonPrimitive(0)
+                    p.isBoolean -> JsonPrimitive(false)
+                    else -> el
+                }
+            }
+            else -> JsonNull.INSTANCE
+        }
+    }
+}

--- a/src/main/kotlin/com/mycompany/markdownproject/template/TemplateStripper.kt
+++ b/src/main/kotlin/com/mycompany/markdownproject/template/TemplateStripper.kt
@@ -1,0 +1,5 @@
+package com.mycompany.markdownproject.template
+
+interface TemplateStripper {
+    fun strip(content: String): String
+}

--- a/src/main/kotlin/com/mycompany/markdownproject/template/TemplateStrippers.kt
+++ b/src/main/kotlin/com/mycompany/markdownproject/template/TemplateStrippers.kt
@@ -1,0 +1,20 @@
+package com.mycompany.markdownproject.template
+
+object TemplateStrippers {
+    private val registry = mutableMapOf<String, TemplateStripper>()
+
+    init {
+        register("yaml", YamlTemplateStripper())
+        register("yml", YamlTemplateStripper())
+        register("json", JsonTemplateStripper())
+        register("toml", TomlTemplateStripper())
+    }
+
+    fun register(lang: String, stripper: TemplateStripper) {
+        registry[lang] = stripper
+    }
+
+    fun supports(lang: String): Boolean = registry.containsKey(lang)
+
+    fun strip(lang: String, content: String): String = registry[lang]?.strip(content) ?: content
+}

--- a/src/main/kotlin/com/mycompany/markdownproject/template/TomlTemplateStripper.kt
+++ b/src/main/kotlin/com/mycompany/markdownproject/template/TomlTemplateStripper.kt
@@ -1,0 +1,15 @@
+package com.mycompany.markdownproject.template
+
+class TomlTemplateStripper : TemplateStripper {
+    override fun strip(content: String): String {
+        return content.lines().joinToString("\n") { line ->
+            val idx = line.indexOf('=')
+            if (idx == -1) line else {
+                val key = line.substring(0, idx).trimEnd()
+                val value = line.substring(idx + 1).trim()
+                val newValue = if (value.startsWith('[')) "[]" else "\"\""
+                "$key = $newValue"
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/mycompany/markdownproject/template/YamlTemplateStripper.kt
+++ b/src/main/kotlin/com/mycompany/markdownproject/template/YamlTemplateStripper.kt
@@ -1,0 +1,23 @@
+package com.mycompany.markdownproject.template
+
+class YamlTemplateStripper : TemplateStripper {
+    override fun strip(content: String): String {
+        return content.lines().joinToString("\n") { line ->
+            stripYamlLine(line)
+        }
+    }
+
+    private fun stripYamlLine(line: String): String {
+        val pair = line.split(":", limit = 2)
+        if (pair.size != 2) return line
+        val key = pair[0]
+        val valuePart = pair[1].trim()
+        return when {
+            valuePart.startsWith(">") -> "$key: >\n  \u2022"
+            valuePart.startsWith("|") -> "$key: |\n  \u2022"
+            valuePart.startsWith("-") -> line.replace(Regex("-\\s+.*"), "- ")
+            valuePart.startsWith("[") -> "$key: []"
+            else -> "$key: \"\""
+        }
+    }
+}

--- a/src/main/kotlin/com/mycompany/markdownproject/toolwindow/NavigationToolWindowFactory.kt
+++ b/src/main/kotlin/com/mycompany/markdownproject/toolwindow/NavigationToolWindowFactory.kt
@@ -1,0 +1,98 @@
+package com.mycompany.markdownproject.toolwindow
+
+import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.openapi.fileEditor.FileDocumentManagerListener
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.wm.ToolWindow
+import com.intellij.openapi.wm.ToolWindowFactory
+import com.intellij.ui.components.JBList
+import com.intellij.ui.components.JBTextField
+import com.intellij.util.ui.components.BorderLayoutPanel
+import com.intellij.openapi.fileEditor.FileEditorManager
+import org.intellij.plugins.markdown.lang.psi.impl.MarkdownFile
+import javax.swing.DefaultListModel
+import javax.swing.DropMode
+import javax.swing.TransferHandler
+import java.awt.datatransfer.DataFlavor
+import java.awt.datatransfer.StringSelection
+import com.intellij.openapi.command.WriteCommandAction
+
+class NavigationToolWindowFactory : ToolWindowFactory {
+    data class Section(val text: String, val start: Int, val end: Int, val content: String)
+
+    override fun createToolWindowContent(project: Project, toolWindow: ToolWindow) {
+        val panel = BorderLayoutPanel()
+        val model = DefaultListModel<Section>()
+        val list = JBList(model)
+        list.dropMode = DropMode.INSERT
+        list.dragEnabled = true
+        val search = JBTextField()
+        panel.addToTop(search)
+        panel.addToCenter(list)
+        val content = toolWindow.contentManager.factory.createContent(panel, "Navigation", false)
+        toolWindow.contentManager.addContent(content)
+
+        list.transferHandler = object : TransferHandler() {
+            override fun getSourceActions(c: javax.swing.JComponent) = MOVE
+            override fun createTransferable(c: javax.swing.JComponent) = StringSelection(list.selectedIndex.toString())
+            override fun importData(support: TransferSupport): Boolean {
+                val from = support.transferable.getTransferData(DataFlavor.stringFlavor).toString().toInt()
+                val to = (support.dropLocation as? JList.DropLocation)?.index ?: return false
+                if (from == to) return false
+                val doc = FileEditorManager.getInstance(project).selectedTextEditor?.document ?: return false
+                val sections = (0 until model.size).map { model.getElementAt(it) }.toMutableList()
+                val moved = sections.removeAt(from)
+                sections.add(if (from < to) to - 1 else to, moved)
+                WriteCommandAction.runWriteCommandAction(project) {
+                    val prefix = doc.text.substring(0, sections.first().start)
+                    val newText = StringBuilder(prefix)
+                    sections.forEach { newText.append(it.content) }
+                    doc.setText(newText.toString())
+                }
+                model.removeAllElements()
+                sections.forEach { model.addElement(it) }
+                return true
+            }
+        }
+
+        project.messageBus.connect().subscribe(FileDocumentManagerListener.TOPIC, object : FileDocumentManagerListener {
+            override fun beforeDocumentSaving(document: com.intellij.openapi.editor.Document) {
+                val file = FileDocumentManager.getInstance().getFile(document) ?: return
+                if (file.fileType.defaultExtension == "md") {
+                    val sections = mutableListOf<Section>()
+                    var offset = 0
+                    var currentStart = -1
+                    var currentText = ""
+                    var builder = StringBuilder()
+                    document.text.lines().forEach { line ->
+                        if (line.startsWith("#")) {
+                            if (currentStart != -1) {
+                                val sectionText = builder.toString()
+                                sections.add(Section(currentText, currentStart, offset, sectionText))
+                                builder = StringBuilder()
+                            }
+                            currentStart = offset
+                            currentText = line.trim()
+                        }
+                        builder.append(line).append('\n')
+                        offset += line.length + 1
+                    }
+                    if (currentStart != -1) {
+                        val sectionText = builder.toString()
+                        sections.add(Section(currentText, currentStart, offset, sectionText))
+                    }
+                    model.removeAllElements()
+                    val filtered = sections.filter { it.text.contains(search.text, ignoreCase = true) }
+                    filtered.forEach { model.addElement(it) }
+                }
+            }
+        })
+
+        list.addListSelectionListener {
+            val entry = list.selectedValue ?: return@addListSelectionListener
+            val editor = FileEditorManager.getInstance(project).selectedTextEditor ?: return@addListSelectionListener
+            editor.caretModel.moveToOffset(entry.start)
+            editor.scrollingModel.scrollToCaret(com.intellij.openapi.editor.ScrollType.CENTER)
+        }
+    }
+}

--- a/src/main/kotlin/com/mycompany/markdownproject/wizard/MarkdownProjectGenerator.kt
+++ b/src/main/kotlin/com/mycompany/markdownproject/wizard/MarkdownProjectGenerator.kt
@@ -1,0 +1,51 @@
+package com.mycompany.markdownproject.wizard
+
+import com.intellij.platform.DirectoryProjectGenerator
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.module.Module
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.vfs.VfsUtil
+import com.intellij.facet.ui.ValidationResult
+import javax.swing.*
+
+data class TemplateSettings(var template: Template = Template.DOCS) {
+    enum class Template { DOCS, BLOG, API }
+}
+
+class MarkdownProjectGenerator : DirectoryProjectGenerator<TemplateSettings> {
+    private var settingsPanel: JPanel? = null
+    override fun getName(): String = "Markdown Project"
+    override fun getDescription(): String = "Create a project containing Markdown documentation"
+    override fun getLogo(): Icon? = null
+
+    override fun generateProject(project: Project, baseDir: VirtualFile, settings: TemplateSettings, module: Module) {
+        val docs = when (settings.template) {
+            TemplateSettings.Template.DOCS -> VfsUtil.createDirectoryIfMissing(baseDir, "docs")
+            TemplateSettings.Template.BLOG -> VfsUtil.createDirectoryIfMissing(baseDir, "blog")
+            TemplateSettings.Template.API -> VfsUtil.createDirectoryIfMissing(baseDir, "api-docs")
+        } ?: return
+        val readme = docs.findOrCreateChildData(this, "README.md")
+        VfsUtil.saveText(readme, "# ${project.name}\n")
+        val editorconfig = baseDir.findOrCreateChildData(this, ".editorconfig")
+        VfsUtil.saveText(editorconfig, "root = true\n\n[*]\ncharset = utf-8\n")
+    }
+
+    override fun validate(baseDirPath: String): ValidationResult = ValidationResult.OK
+
+    fun showGenerationSettings(baseDir: VirtualFile): JComponent {
+        val panel = JPanel()
+        val combo = JComboBox(TemplateSettings.Template.values())
+        panel.add(JLabel("Template:"))
+        panel.add(combo)
+        panel.putClientProperty("combo", combo)
+        settingsPanel = panel
+        return panel
+    }
+
+    fun getSettings(): TemplateSettings {
+        val panel = settingsPanel
+        val combo = panel?.getClientProperty("combo") as? JComboBox<*> ?: return TemplateSettings()
+        @Suppress("UNCHECKED_CAST")
+        return TemplateSettings(combo.selectedItem as TemplateSettings.Template)
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,24 +1,68 @@
-<!-- Plugin Configuration File. Read more: https://plugins.jetbrains.com/docs/intellij/plugin-configuration-file.html -->
 <idea-plugin>
-    <id>org.jetbrains.plugins.tkdesigner</id>
-    <name>Visual Tkinter Designer</name>
-    <vendor url="https://github.com/openai">Codex</vendor>
+    <id>com.mycompany.markdownproject</id>
+    <name>Markdown Project Creator</name>
+    <vendor url="https://mycompany.com">MyCompany</vendor>
 
     <depends>com.intellij.modules.platform</depends>
-
-    <resource-bundle>messages.TkDesignerBundle</resource-bundle>
-    <icon>icons/pluginIcon.svg</icon>
+    <depends>com.intellij.modules.lang</depends>
+    <depends>org.intellij.plugins.markdown</depends>
 
     <extensions defaultExtensionNs="com.intellij">
-        <toolWindow factoryClass="org.jetbrains.plugins.template.tkdesigner.TkinterDesignerToolWindowFactory" id="TkinterDesigner" anchor="right"/>
-        <diffTool implementation="org.jetbrains.plugins.template.tkdesigner.TkdesignDiffTool"/>
-        <applicationService serviceImplementation="org.jetbrains.plugins.template.tkdesigner.DesignerSettings"/>
-        <applicationConfigurable id="tkdesigner" displayName="Tkinter Designer" instance="org.jetbrains.plugins.template.tkdesigner.settings.DesignerSettingsConfigurable"/>
-        <configurationType implementation="org.jetbrains.plugins.template.tkdesigner.run.TkPreviewRunConfigurationType"/>
-        <extensionPoint name="customWidget" interface="org.jetbrains.plugins.template.tkdesigner.model.CustomWidgetRegistrar"/>
+        <directoryProjectGenerator implementation="com.mycompany.markdownproject.wizard.MarkdownProjectGenerator" />
+        <editorActionHandler action="EditorPaste" implementationClass="com.mycompany.markdownproject.paste.MarkdownPasteHandler" />
+        <fileDropHandler implementation="com.mycompany.markdownproject.paste.ImageDropHandler" />
+        <applicationService serviceImplementation="com.mycompany.markdownproject.settings.MarkdownPasteSettings" />
+        <applicationService serviceImplementation="com.mycompany.markdownproject.draft.DraftService" />
+        <applicationService serviceImplementation="com.mycompany.markdownproject.snippets.SnippetService" />
+        <applicationConfigurable id="markdown.paste" displayName="Markdown Paste" instance="com.mycompany.markdownproject.settings.MarkdownPasteConfigurable" />
+        <projectType id="MARKDOWN" name="Markdown Project" />
+        <projectService serviceImplementation="com.mycompany.markdownproject.tasks.TaskService" />
+        <projectService serviceImplementation="com.mycompany.markdownproject.history.LinkHistoryService" />
+        <localInspection language="Markdown" shortName="MarkdownLint" implementationClass="com.mycompany.markdownproject.inspections.MarkdownLintInspection" displayName="Markdown Lint" />
+        <localInspection language="Markdown" shortName="BrokenLink" implementationClass="com.mycompany.markdownproject.inspections.BrokenLinkInspection" displayName="Broken Link" />
+        <listener class="com.mycompany.markdownproject.draft.DraftListener" topic="com.intellij.openapi.editor.event.EditorFactoryListener" />
+        <listener class="com.mycompany.markdownproject.draft.DraftRestorer" topic="com.intellij.openapi.editor.event.EditorFactoryListener" />
+        <listener class="com.mycompany.markdownproject.tasks.TaskUpdater" topic="com.intellij.openapi.fileEditor.FileDocumentManagerListener" />
+        <toolWindow id="MarkdownNav" factoryClass="com.mycompany.markdownproject.toolwindow.NavigationToolWindowFactory" anchor="left"/>
+        <completion.contributor language="Markdown" implementationClass="com.mycompany.markdownproject.completion.LinkCompletionContributor" order="first" />
+        <spellchecker.support implementation="com.mycompany.markdownproject.spellcheck.MarkdownSpellcheckStrategy" />
     </extensions>
     <actions>
-        <action id="TkinterDesigner.Open" class="org.jetbrains.plugins.template.tkdesigner.OpenDesignerAction"
-                text="%action.openDesigner.text" description="%action.openDesigner.description"/>
+        <action id="Markdown.InsertTable" class="com.mycompany.markdownproject.actions.InsertTableAction" text="Insert Table">
+            <keyboard-shortcut first-keystroke="ctrl alt T"/>
+        </action>
+        <action id="Markdown.InsertCodeBlock" class="com.mycompany.markdownproject.actions.InsertCodeBlockAction" text="Insert Code Block">
+            <keyboard-shortcut first-keystroke="ctrl alt C"/>
+        </action>
+        <action id="Markdown.InsertImage" class="com.mycompany.markdownproject.actions.InsertImageAction" text="Insert Image">
+            <keyboard-shortcut first-keystroke="ctrl alt I"/>
+        </action>
+        <action id="Markdown.GenerateToc" class="com.mycompany.markdownproject.actions.GenerateTocAction" text="Generate TOC">
+            <keyboard-shortcut first-keystroke="ctrl alt shift T"/>
+        </action>
+        <action id="Markdown.CopyAsTemplate" class="com.mycompany.markdownproject.actions.CopyCodeBlockAsTemplateAction" text="Copy as Template" icon="AllIcons.Actions.Copy">
+            <add-to-group group-id="EditorPopupMenu" anchor="first"/>
+        </action>
+        <action id="Markdown.InsertFrontMatter" class="com.mycompany.markdownproject.actions.InsertFrontMatterAction" text="Insert Front Matter">
+            <keyboard-shortcut first-keystroke="ctrl alt M"/>
+        </action>
+        <action id="Markdown.InsertSnippet" class="com.mycompany.markdownproject.actions.InsertSnippetAction" text="Insert Snippet">
+            <keyboard-shortcut first-keystroke="ctrl alt S"/>
+        </action>
+        <action id="Markdown.ExportHtml" class="com.mycompany.markdownproject.actions.ExportHtmlAction" text="Export Document">
+            <keyboard-shortcut first-keystroke="ctrl alt E"/>
+        </action>
+        <action id="Markdown.ConvertHtmlSelection" class="com.mycompany.markdownproject.actions.ConvertSelectionHtmlAction" text="Convert HTML Selection">
+            <keyboard-shortcut first-keystroke="ctrl alt H"/>
+        </action>
+        <action id="Markdown.FixFormatting" class="com.mycompany.markdownproject.actions.FixFormattingAction" text="Fix Markdown Formatting">
+            <keyboard-shortcut first-keystroke="ctrl alt F"/>
+        </action>
+        <action id="Markdown.InsertCitation" class="com.mycompany.markdownproject.actions.InsertCitationAction" text="Insert Citation">
+            <keyboard-shortcut first-keystroke="ctrl alt shift C"/>
+        </action>
+        <action id="Markdown.GenerateReleaseNotes" class="com.mycompany.markdownproject.actions.GenerateReleaseNotesAction" text="Generate Release Notes">
+            <keyboard-shortcut first-keystroke="ctrl alt R"/>
+        </action>
     </actions>
 </idea-plugin>


### PR DESCRIPTION
## Summary
- support `Copy as Template` action when a fenced code block is selected
- provide `TemplateStripper` framework for YAML, JSON, and TOML
- insert the action in editor popup menu with copy icon
- update README to mention supported languages
- add drag-and-drop heading reordering via navigation tool window
- detect broken links and offer quick fix
- generate Markdown release notes from recent Git commits

## Testing
- `./gradlew buildPlugin -x signPlugin --no-daemon` *(fails: Calculating task graph as no cached configuration is available for tasks: buildPlugin)*

------
https://chatgpt.com/codex/tasks/task_e_685f510e3ca08330b5854610a230c474