### PR TITLE
Add new markdown editing tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Markdown Project Creator is an IntelliJ IDEA plugin for quickly starting Markdow
 ## Features
 
 - New project wizard entry with templates for docs, blogs and API docs
+- Markdown Project type available in the New Project dialog
 - `.editorconfig` added with UTF-8 encoding
 - Paste handler that converts HTML clipboard content to clean Markdown on paste
 - Images pasted or dropped are optimized, saved locally and referenced in Markdown
@@ -15,6 +16,7 @@ Markdown Project Creator is an IntelliJ IDEA plugin for quickly starting Markdow
 - Quick actions to insert tables, code blocks and images
 - "Copy as Template" action for YAML, JSON and TOML code blocks
 - Convert selected HTML to Markdown via **Convert HTML Selection** action
+- Convert highlighted HTML to Markdown from the editor context menu
 - "Fix Markdown Formatting" action to reformat the current document
 - Auto-saves Markdown drafts across IDE sessions
 - Generate or update a Table of Contents for README files using `<!-- TOC -->` markers
@@ -22,6 +24,7 @@ Markdown Project Creator is an IntelliJ IDEA plugin for quickly starting Markdow
 - Lint inspection with quick fix for trailing spaces
 - Snippet library with reusable blocks and front matter insertion; placeholders update across documents
 - Export Markdown to HTML or PDF
+- "Paste from Browser" action converts copied web content to Markdown
 - Setting under **Tools | Markdown Paste** to disable the auto-convert behaviour
 - Navigation tool window to browse headings, code blocks and anchors
 - Drag-and-drop heading reordering from the navigation tool window
@@ -32,6 +35,10 @@ Markdown Project Creator is an IntelliJ IDEA plugin for quickly starting Markdow
 - Insert citations as numbered footnotes
 - Spellcheck ignores code blocks
 - Generate release notes from recent Git commits
+- Insert horizontal rules with one click
+- Blockquote selected lines
+- Toggle strikethrough formatting
+- Convert clipboard URLs into Markdown links
 
 ## Building
 

--- a/src/main/kotlin/com/mycompany/markdownproject/actions/ConvertHtml5SelectionAction.kt
+++ b/src/main/kotlin/com/mycompany/markdownproject/actions/ConvertHtml5SelectionAction.kt
@@ -2,7 +2,7 @@ package com.mycompany.markdownproject.actions
 
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
-import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.editor.EditorModificationUtil
 import com.vladsch.flexmark.formatter.Formatter
@@ -10,16 +10,15 @@ import com.vladsch.flexmark.html2md.converter.FlexmarkHtmlConverter
 import com.vladsch.flexmark.parser.Parser
 import org.jsoup.Jsoup
 
-class ConvertSelectionHtmlAction : AnAction("Convert HTML Selection") {
+class ConvertHtml5SelectionAction : AnAction("Convert HTML5 Selection") {
     private val converter = FlexmarkHtmlConverter.builder().build()
     private val parser = Parser.builder().build()
     private val formatter = Formatter.builder().build()
 
     override fun actionPerformed(e: AnActionEvent) {
-        val editor = e.getData(com.intellij.openapi.actionSystem.CommonDataKeys.EDITOR) ?: return
-        val selection = editor.selectionModel
-        val html = selection.selectedText ?: return
-        val cleaned = Jsoup.parse(html).apply { select("style,script").remove() }.body().html()
+        val editor = e.getData(CommonDataKeys.EDITOR) ?: return
+        val html = editor.selectionModel.selectedText ?: return
+        val cleaned = Jsoup.parse(html).body().html()
         val markdown = converter.convert(cleaned)
         val formatted = formatter.render(parser.parse(markdown))
         WriteCommandAction.runWriteCommandAction(e.project) {
@@ -28,8 +27,8 @@ class ConvertSelectionHtmlAction : AnAction("Convert HTML Selection") {
     }
 
     override fun update(e: AnActionEvent) {
-        val editor = e.getData(com.intellij.openapi.actionSystem.CommonDataKeys.EDITOR)
-        val psiFile = e.getData(com.intellij.openapi.actionSystem.CommonDataKeys.PSI_FILE)
+        val editor = e.getData(CommonDataKeys.EDITOR)
+        val psiFile = e.getData(CommonDataKeys.PSI_FILE)
         val hasSelection = editor?.selectionModel?.hasSelection() ?: false
         val isMarkdown = psiFile?.fileType?.defaultExtension == "md"
         e.presentation.isEnabledAndVisible = hasSelection && isMarkdown

--- a/src/main/kotlin/com/mycompany/markdownproject/actions/InsertBlockquoteAction.kt
+++ b/src/main/kotlin/com/mycompany/markdownproject/actions/InsertBlockquoteAction.kt
@@ -1,0 +1,25 @@
+package com.mycompany.markdownproject.actions
+
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.actionSystem.CommonDataKeys
+
+class InsertBlockquoteAction : AnAction("Insert Blockquote") {
+    override fun actionPerformed(e: AnActionEvent) {
+        val editor = e.getData(CommonDataKeys.EDITOR) ?: return
+        val document = editor.document
+        val selectionModel = editor.selectionModel
+        val start = selectionModel.selectionStart
+        val end = selectionModel.selectionEnd
+        val startLine = document.getLineNumber(start)
+        val endLine = document.getLineNumber(if (selectionModel.hasSelection()) end else start)
+        WriteCommandAction.runWriteCommandAction(editor.project) {
+            for (line in startLine..endLine) {
+                val lineStart = document.getLineStartOffset(line)
+                document.insertString(lineStart, "> ")
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/mycompany/markdownproject/actions/InsertHorizontalRuleAction.kt
+++ b/src/main/kotlin/com/mycompany/markdownproject/actions/InsertHorizontalRuleAction.kt
@@ -1,0 +1,21 @@
+package com.mycompany.markdownproject.actions
+
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.actionSystem.CommonDataKeys
+
+class InsertHorizontalRuleAction : AnAction("Insert Horizontal Rule") {
+    override fun actionPerformed(e: AnActionEvent) {
+        val editor = e.getData(CommonDataKeys.EDITOR) ?: return
+        insertText(editor, "\n---\n")
+    }
+
+    private fun insertText(editor: Editor, text: String) {
+        WriteCommandAction.runWriteCommandAction(editor.project) {
+            val offset = editor.caretModel.offset
+            editor.document.insertString(offset, text)
+        }
+    }
+}

--- a/src/main/kotlin/com/mycompany/markdownproject/actions/InsertStrikethroughAction.kt
+++ b/src/main/kotlin/com/mycompany/markdownproject/actions/InsertStrikethroughAction.kt
@@ -1,0 +1,25 @@
+package com.mycompany.markdownproject.actions
+
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.actionSystem.CommonDataKeys
+
+class InsertStrikethroughAction : AnAction("Insert Strikethrough") {
+    override fun actionPerformed(e: AnActionEvent) {
+        val editor = e.getData(CommonDataKeys.EDITOR) ?: return
+        val selectionModel = editor.selectionModel
+        WriteCommandAction.runWriteCommandAction(editor.project) {
+            if (selectionModel.hasSelection()) {
+                val start = selectionModel.selectionStart
+                val end = selectionModel.selectionEnd
+                editor.document.insertString(end, "~~")
+                editor.document.insertString(start, "~~")
+            } else {
+                val offset = editor.caretModel.offset
+                editor.document.insertString(offset, "~~~~")
+                editor.caretModel.moveToOffset(offset + 2)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/mycompany/markdownproject/actions/LinkFromClipboardAction.kt
+++ b/src/main/kotlin/com/mycompany/markdownproject/actions/LinkFromClipboardAction.kt
@@ -1,0 +1,27 @@
+package com.mycompany.markdownproject.actions
+
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.actionSystem.CommonDataKeys
+import java.awt.datatransfer.DataFlavor
+import java.awt.Toolkit
+
+class LinkFromClipboardAction : AnAction("Insert Link from Clipboard") {
+    override fun actionPerformed(e: AnActionEvent) {
+        val editor = e.getData(CommonDataKeys.EDITOR) ?: return
+        val clipboard = Toolkit.getDefaultToolkit().systemClipboard
+        val url = clipboard.getData(DataFlavor.stringFlavor) as? String ?: return
+        if (!url.startsWith("http")) return
+        val selectionModel = editor.selectionModel
+        WriteCommandAction.runWriteCommandAction(editor.project) {
+            if (selectionModel.hasSelection()) {
+                val text = selectionModel.selectedText ?: ""
+                editor.document.replaceString(selectionModel.selectionStart, selectionModel.selectionEnd, "[$text]($url)")
+            } else {
+                val offset = editor.caretModel.offset
+                editor.document.insertString(offset, "[$url]($url)")
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/mycompany/markdownproject/actions/PasteFromBrowserAction.kt
+++ b/src/main/kotlin/com/mycompany/markdownproject/actions/PasteFromBrowserAction.kt
@@ -1,0 +1,72 @@
+package com.mycompany.markdownproject.actions
+
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.ide.CopyPasteManager
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.editor.Editor
+import com.intellij.psi.PsiDocumentManager
+import com.vladsch.flexmark.html2md.converter.FlexmarkHtmlConverter
+import com.vladsch.flexmark.formatter.Formatter
+import com.vladsch.flexmark.parser.Parser
+import org.jsoup.Jsoup
+import java.awt.datatransfer.DataFlavor
+import java.awt.datatransfer.Transferable
+
+class PasteFromBrowserAction : AnAction("Paste from Browser") {
+    private val htmlConverter = FlexmarkHtmlConverter.builder().build()
+    private val parser = Parser.builder().build()
+    private val formatter = Formatter.builder().build()
+
+    override fun actionPerformed(e: AnActionEvent) {
+        val editor = e.getRequiredData(CommonDataKeys.EDITOR)
+        val project = e.project ?: return
+        val html = extractHtml(CopyPasteManager.getInstance().contents) ?: return
+        val state = com.mycompany.markdownproject.settings.MarkdownPasteSettings.instance().state
+        val cleaned = sanitizeHtml(html, state)
+        val markdown = htmlConverter.convert(cleaned)
+        val formatted = formatter.render(parser.parse(markdown))
+        WriteCommandAction.runWriteCommandAction(project) {
+            val sel = editor.selectionModel
+            editor.document.replaceString(sel.selectionStart, sel.selectionEnd, formatted)
+            PsiDocumentManager.getInstance(project).commitDocument(editor.document)
+        }
+    }
+
+    private fun extractHtml(transferable: Transferable?): String? {
+        if (transferable == null) return null
+        listOf(DataFlavor.fragmentHtmlFlavor, DataFlavor.allHtmlFlavor).forEach { flavor ->
+            if (transferable.isDataFlavorSupported(flavor)) {
+                return transferable.getTransferData(flavor) as? String
+            }
+        }
+        if (transferable.isDataFlavorSupported(DataFlavor.stringFlavor)) {
+            val text = transferable.getTransferData(DataFlavor.stringFlavor) as? String
+            if (text != null && text.contains('<') && text.contains('>')) {
+                return text
+            }
+        }
+        return null
+    }
+
+    private fun sanitizeHtml(html: String, settings: com.mycompany.markdownproject.settings.MarkdownPasteSettings.State): String {
+        val doc = Jsoup.parse(html)
+        doc.select("style,script").remove()
+        settings.excludedTags.forEach { tag ->
+            doc.select(tag).remove()
+        }
+        settings.tagMappings.forEach { (from, to) ->
+            doc.select(from).forEach { e -> e.tagName(to) }
+        }
+        doc.select("[style*=font-weight:bold]").forEach { element ->
+            element.tagName(settings.tagMappings.getOrDefault("b", "b"))
+            element.removeAttr("style")
+        }
+        doc.select("[style*=font-style:italic]").forEach { element ->
+            element.tagName(settings.tagMappings.getOrDefault("i", "i"))
+            element.removeAttr("style")
+        }
+        return doc.body().html()
+    }
+}

--- a/src/main/kotlin/com/mycompany/markdownproject/paste/MarkdownPasteHandler.kt
+++ b/src/main/kotlin/com/mycompany/markdownproject/paste/MarkdownPasteHandler.kt
@@ -22,7 +22,11 @@ import java.awt.Graphics2D
 import java.io.ByteArrayOutputStream
 
 class MarkdownPasteHandler : EditorActionHandler() {
-    private val original = EditorActionManager.getInstance().getActionHandler(IdeActions.ACTION_PASTE)
+    // Use the editor specific paste action so the returned handler is an
+    // EditorActionHandler. Using IdeActions.ACTION_PASTE causes a
+    // ClassCastException because that ID refers to a generic AnAction.
+    private val original = EditorActionManager.getInstance()
+        .getActionHandler(IdeActions.ACTION_EDITOR_PASTE)
     private val htmlConverter = FlexmarkHtmlConverter.builder().build()
     private val parser = Parser.builder().build()
     private val formatter = Formatter.builder().build()

--- a/src/main/kotlin/com/mycompany/markdownproject/wizard/MarkdownModuleBuilder.kt
+++ b/src/main/kotlin/com/mycompany/markdownproject/wizard/MarkdownModuleBuilder.kt
@@ -1,0 +1,25 @@
+package com.mycompany.markdownproject.wizard
+
+import com.intellij.ide.util.projectWizard.ModuleBuilder
+import com.intellij.openapi.module.ModuleType
+import com.intellij.openapi.roots.ModifiableRootModel
+import com.intellij.openapi.vfs.VfsUtil
+import java.io.IOException
+
+class MarkdownModuleBuilder : ModuleBuilder() {
+    override fun getModuleType(): ModuleType<MarkdownModuleBuilder> = MarkdownModuleType.instance
+
+    override fun setupRootModel(model: ModifiableRootModel) {
+        val base = contentEntryPath?.let { VfsUtil.createDirectories(it) } ?: return
+        model.addContentEntry(base)
+        try {
+            val docs = VfsUtil.createDirectoryIfMissing(base, "docs")
+            val readme = docs?.findOrCreateChildData(this, "README.md")
+            if (readme != null) {
+                VfsUtil.saveText(readme, "# ${model.project.name}\n")
+            }
+        } catch (_: IOException) {
+            // ignore IO issues during setup
+        }
+    }
+}

--- a/src/main/kotlin/com/mycompany/markdownproject/wizard/MarkdownModuleType.kt
+++ b/src/main/kotlin/com/mycompany/markdownproject/wizard/MarkdownModuleType.kt
@@ -1,0 +1,20 @@
+package com.mycompany.markdownproject.wizard
+
+import com.intellij.openapi.module.ModuleType
+import com.intellij.openapi.module.ModuleTypeManager
+import com.intellij.ide.util.projectWizard.ModuleWizardStep
+import javax.swing.Icon
+import com.intellij.icons.AllIcons
+
+class MarkdownModuleType : ModuleType<MarkdownModuleBuilder>(ID) {
+    companion object {
+        const val ID = "MARKDOWN_MODULE_TYPE"
+        val instance: MarkdownModuleType
+            get() = ModuleTypeManager.getInstance().findByID(ID) as MarkdownModuleType
+    }
+
+    override fun createModuleBuilder() = MarkdownModuleBuilder()
+    override fun getName() = "Markdown Project"
+    override fun getDescription() = "Project type for Markdown documentation"
+    override fun getNodeIcon(isOpened: Boolean): Icon = AllIcons.FileTypes.Markdown
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -16,6 +16,7 @@
         <applicationService serviceImplementation="com.mycompany.markdownproject.snippets.SnippetService" />
         <applicationConfigurable id="markdown.paste" displayName="Markdown Paste" instance="com.mycompany.markdownproject.settings.MarkdownPasteConfigurable" />
         <projectType id="MARKDOWN" name="Markdown Project" />
+        <moduleType id="MARKDOWN_MODULE_TYPE" implementationClass="com.mycompany.markdownproject.wizard.MarkdownModuleType"/>
         <projectService serviceImplementation="com.mycompany.markdownproject.tasks.TaskService" />
         <projectService serviceImplementation="com.mycompany.markdownproject.history.LinkHistoryService" />
         <localInspection language="Markdown" shortName="MarkdownLint" implementationClass="com.mycompany.markdownproject.inspections.MarkdownLintInspection" displayName="Markdown Lint" />
@@ -28,41 +29,99 @@
         <spellchecker.support implementation="com.mycompany.markdownproject.spellcheck.MarkdownSpellcheckStrategy" />
     </extensions>
     <actions>
+        <group id="MarkdownToolsGroup" text="Markdown Tools" popup="true">
+            <add-to-group group-id="ToolsMenu" anchor="last"/>
+        </group>
+        <group id="MarkdownPopupGroup" text="Markdown Tools" popup="true">
+            <add-to-group group-id="EditorPopupMenu" anchor="last"/>
+        </group>
         <action id="Markdown.InsertTable" class="com.mycompany.markdownproject.actions.InsertTableAction" text="Insert Table">
-            <keyboard-shortcut first-keystroke="ctrl alt T"/>
+            <keyboard-shortcut keymap="$default" first-keystroke="ctrl alt T"/>
+            <add-to-group group-id="MarkdownToolsGroup"/>
+            <add-to-group group-id="MarkdownPopupGroup"/>
         </action>
         <action id="Markdown.InsertCodeBlock" class="com.mycompany.markdownproject.actions.InsertCodeBlockAction" text="Insert Code Block">
-            <keyboard-shortcut first-keystroke="ctrl alt C"/>
+            <keyboard-shortcut keymap="$default" first-keystroke="ctrl alt C"/>
+            <add-to-group group-id="MarkdownToolsGroup"/>
+            <add-to-group group-id="MarkdownPopupGroup"/>
         </action>
         <action id="Markdown.InsertImage" class="com.mycompany.markdownproject.actions.InsertImageAction" text="Insert Image">
-            <keyboard-shortcut first-keystroke="ctrl alt I"/>
+            <keyboard-shortcut keymap="$default" first-keystroke="ctrl alt I"/>
+            <add-to-group group-id="MarkdownToolsGroup"/>
+            <add-to-group group-id="MarkdownPopupGroup"/>
         </action>
         <action id="Markdown.GenerateToc" class="com.mycompany.markdownproject.actions.GenerateTocAction" text="Generate TOC">
-            <keyboard-shortcut first-keystroke="ctrl alt shift T"/>
+            <keyboard-shortcut keymap="$default" first-keystroke="ctrl alt shift T"/>
+            <add-to-group group-id="MarkdownToolsGroup"/>
+            <add-to-group group-id="MarkdownPopupGroup"/>
         </action>
         <action id="Markdown.CopyAsTemplate" class="com.mycompany.markdownproject.actions.CopyCodeBlockAsTemplateAction" text="Copy as Template" icon="AllIcons.Actions.Copy">
             <add-to-group group-id="EditorPopupMenu" anchor="first"/>
+            <add-to-group group-id="MarkdownToolsGroup"/>
+            <add-to-group group-id="MarkdownPopupGroup"/>
         </action>
         <action id="Markdown.InsertFrontMatter" class="com.mycompany.markdownproject.actions.InsertFrontMatterAction" text="Insert Front Matter">
-            <keyboard-shortcut first-keystroke="ctrl alt M"/>
+            <keyboard-shortcut keymap="$default" first-keystroke="ctrl alt M"/>
+            <add-to-group group-id="MarkdownToolsGroup"/>
+            <add-to-group group-id="MarkdownPopupGroup"/>
         </action>
         <action id="Markdown.InsertSnippet" class="com.mycompany.markdownproject.actions.InsertSnippetAction" text="Insert Snippet">
-            <keyboard-shortcut first-keystroke="ctrl alt S"/>
+            <keyboard-shortcut keymap="$default" first-keystroke="ctrl alt S"/>
+            <add-to-group group-id="MarkdownToolsGroup"/>
+            <add-to-group group-id="MarkdownPopupGroup"/>
         </action>
         <action id="Markdown.ExportHtml" class="com.mycompany.markdownproject.actions.ExportHtmlAction" text="Export Document">
-            <keyboard-shortcut first-keystroke="ctrl alt E"/>
+            <keyboard-shortcut keymap="$default" first-keystroke="ctrl alt E"/>
+            <add-to-group group-id="MarkdownToolsGroup"/>
+            <add-to-group group-id="MarkdownPopupGroup"/>
         </action>
         <action id="Markdown.ConvertHtmlSelection" class="com.mycompany.markdownproject.actions.ConvertSelectionHtmlAction" text="Convert HTML Selection">
-            <keyboard-shortcut first-keystroke="ctrl alt H"/>
+            <keyboard-shortcut keymap="$default" first-keystroke="ctrl alt H"/>
+            <add-to-group group-id="MarkdownToolsGroup"/>
+            <add-to-group group-id="MarkdownPopupGroup"/>
+        </action>
+        <action id="Markdown.ConvertHtml5Selection" class="com.mycompany.markdownproject.actions.ConvertHtml5SelectionAction" text="Convert Highlighted HTML">
+            <add-to-group group-id="MarkdownPopupGroup"/>
         </action>
         <action id="Markdown.FixFormatting" class="com.mycompany.markdownproject.actions.FixFormattingAction" text="Fix Markdown Formatting">
-            <keyboard-shortcut first-keystroke="ctrl alt F"/>
+            <keyboard-shortcut keymap="$default" first-keystroke="ctrl alt F"/>
+            <add-to-group group-id="MarkdownToolsGroup"/>
+            <add-to-group group-id="MarkdownPopupGroup"/>
         </action>
         <action id="Markdown.InsertCitation" class="com.mycompany.markdownproject.actions.InsertCitationAction" text="Insert Citation">
-            <keyboard-shortcut first-keystroke="ctrl alt shift C"/>
+            <keyboard-shortcut keymap="$default" first-keystroke="ctrl alt shift C"/>
+            <add-to-group group-id="MarkdownToolsGroup"/>
+            <add-to-group group-id="MarkdownPopupGroup"/>
         </action>
         <action id="Markdown.GenerateReleaseNotes" class="com.mycompany.markdownproject.actions.GenerateReleaseNotesAction" text="Generate Release Notes">
-            <keyboard-shortcut first-keystroke="ctrl alt R"/>
+            <keyboard-shortcut keymap="$default" first-keystroke="ctrl alt R"/>
+            <add-to-group group-id="MarkdownToolsGroup"/>
+            <add-to-group group-id="MarkdownPopupGroup"/>
+        </action>
+        <action id="Markdown.PasteFromBrowser" class="com.mycompany.markdownproject.actions.PasteFromBrowserAction" text="Paste from Browser">
+            <keyboard-shortcut keymap="$default" first-keystroke="ctrl shift V"/>
+            <add-to-group group-id="MarkdownToolsGroup"/>
+            <add-to-group group-id="MarkdownPopupGroup"/>
+        </action>
+        <action id="Markdown.InsertHorizontalRule" class="com.mycompany.markdownproject.actions.InsertHorizontalRuleAction" text="Insert Horizontal Rule">
+            <keyboard-shortcut keymap="$default" first-keystroke="ctrl alt J"/>
+            <add-to-group group-id="MarkdownToolsGroup"/>
+            <add-to-group group-id="MarkdownPopupGroup"/>
+        </action>
+        <action id="Markdown.InsertBlockquote" class="com.mycompany.markdownproject.actions.InsertBlockquoteAction" text="Insert Blockquote">
+            <keyboard-shortcut keymap="$default" first-keystroke="ctrl alt Q"/>
+            <add-to-group group-id="MarkdownToolsGroup"/>
+            <add-to-group group-id="MarkdownPopupGroup"/>
+        </action>
+        <action id="Markdown.InsertStrikethrough" class="com.mycompany.markdownproject.actions.InsertStrikethroughAction" text="Insert Strikethrough">
+            <keyboard-shortcut keymap="$default" first-keystroke="ctrl alt D"/>
+            <add-to-group group-id="MarkdownToolsGroup"/>
+            <add-to-group group-id="MarkdownPopupGroup"/>
+        </action>
+        <action id="Markdown.LinkFromClipboard" class="com.mycompany.markdownproject.actions.LinkFromClipboardAction" text="Insert Link from Clipboard">
+            <keyboard-shortcut keymap="$default" first-keystroke="ctrl alt L"/>
+            <add-to-group group-id="MarkdownToolsGroup"/>
+            <add-to-group group-id="MarkdownPopupGroup"/>
         </action>
     </actions>
 </idea-plugin>


### PR DESCRIPTION
## Summary
- expand the Markdown Tools submenu with more options
- add Insert Horizontal Rule, Blockquote, Strikethrough, and Link From Clipboard actions
- document the new features in the README
- add context action to convert highlighted HTML to Markdown
- provide Markdown project module type for new project dialog

## Testing
- `./gradlew test --no-daemon --console=plain --stacktrace` *(fails: Calculating task graph)*


------
https://chatgpt.com/codex/tasks/task_e_68671a6b0a9c83308892d4917ccc3aab