### PR TITLE
Fix paste handler for non-markdown fields

### DIFF
--- a/src/main/kotlin/com/mycompany/markdownproject/paste/MarkdownPasteHandler.kt
+++ b/src/main/kotlin/com/mycompany/markdownproject/paste/MarkdownPasteHandler.kt
@@ -31,6 +31,19 @@ class MarkdownPasteHandler : EditorActionHandler() {
     private val parser = Parser.builder().build()
     private val formatter = Formatter.builder().build()
 
+    override fun isEnabledForCaret(editor: Editor, caret: Caret, dataContext: DataContext): Boolean {
+        val project = editor.project ?: return original.isEnabled(editor, caret, dataContext)
+        val psiFile = PsiDocumentManager.getInstance(project).getPsiFile(editor.document)
+        if (psiFile == null || psiFile.fileType.defaultExtension != "md") {
+            return original.isEnabled(editor, caret, dataContext)
+        }
+        val state = com.mycompany.markdownproject.settings.MarkdownPasteSettings.instance().state
+        if (!state.autoConvert) {
+            return original.isEnabled(editor, caret, dataContext)
+        }
+        return true
+    }
+
     private fun extractHtml(transferable: Transferable?): String? {
         if (transferable == null) return null
         listOf(DataFlavor.fragmentHtmlFlavor, DataFlavor.allHtmlFlavor).forEach { flavor ->

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -9,7 +9,7 @@
 
     <extensions defaultExtensionNs="com.intellij">
         <directoryProjectGenerator implementation="com.mycompany.markdownproject.wizard.MarkdownProjectGenerator" />
-        <editorActionHandler action="EditorPaste" implementationClass="com.mycompany.markdownproject.paste.MarkdownPasteHandler" />
+        <editorActionHandler action="EditorPaste" implementationClass="com.mycompany.markdownproject.paste.MarkdownPasteHandler" language="Markdown" />
         <fileDropHandler implementation="com.mycompany.markdownproject.paste.ImageDropHandler" />
         <applicationService serviceImplementation="com.mycompany.markdownproject.settings.MarkdownPasteSettings" />
         <applicationService serviceImplementation="com.mycompany.markdownproject.draft.DraftService" />


### PR DESCRIPTION
## Summary
- only activate MarkdownPasteHandler in Markdown editors

## Testing
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_686831ae3c7483308818b00c44a1494b