### PR TITLE
Fix selection handling in paste handler

### DIFF
--- a/src/main/kotlin/com/mycompany/markdownproject/paste/MarkdownPasteHandler.kt
+++ b/src/main/kotlin/com/mycompany/markdownproject/paste/MarkdownPasteHandler.kt
@@ -108,7 +108,13 @@ class MarkdownPasteHandler : EditorActionHandler() {
         }
         if (text != null) {
             WriteCommandAction.runWriteCommandAction(editor.project) {
-                editor.document.insertString(editor.caretModel.offset, text)
+                val model = editor.selectionModel
+                if (model.hasSelection()) {
+                    editor.document.replaceString(model.selectionStart, model.selectionEnd, text)
+                } else {
+                    editor.document.insertString(editor.caretModel.offset, text)
+                }
+                editor.project?.let { PsiDocumentManager.getInstance(it).commitDocument(editor.document) }
             }
         }
     }


### PR DESCRIPTION
## Summary
- ensure pasting plain text replaces selection if one exists

## Testing
- `./gradlew buildPlugin -x signPlugin --no-daemon --console=plain`

------
https://chatgpt.com/codex/tasks/task_e_686aefefcd788330993ced7773a003ff